### PR TITLE
Bump version to 0.10.32 and fix memory leaks

### DIFF
--- a/client/extension/extension.ts
+++ b/client/extension/extension.ts
@@ -7,6 +7,7 @@
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
+import * as child_process from 'child_process';
 import * as vs from 'vscode';
 import { workspace, ExtensionContext, window, Disposable, Uri, WorkspaceEdit, TextEdit, Range, commands, env } from 'vscode';
 import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind, NotificationType, ExecuteCommandRequest, ExecuteCommandParams, RevealOutputChannelOn } from 'vscode-languageclient/node';
@@ -27,16 +28,15 @@ const ck3Remote = `https://github.com/cwtools/cwtools-ck3-config`;
 const eu5Remote = `https://github.com/kaiser-chris/cwtools-eu5-config`;
 
 export let defaultClient: LanguageClient;
-let fileList : FileListItem[];
-let fileExplorer : FileExplorer;
+let fileList: FileListItem[];
+let fileExplorer: FileExplorer;
 export async function activate(context: ExtensionContext) {
 
 
-	class CwtoolsProvider implements vs.TextDocumentContentProvider
-	{
+	class CwtoolsProvider implements vs.TextDocumentContentProvider {
 		private disposables: Disposable[] = [];
 
-		constructor(){
+		constructor() {
 			workspace.registerTextDocumentContentProvider("cwtools", this)
 		}
 		async provideTextDocumentContent() {
@@ -51,8 +51,8 @@ export async function activate(context: ExtensionContext) {
 	const isDevDir = env.machineId === "someValue.machineId"
 	const cacheDir = isDevDir ? context.globalStorageUri + '/.cwtools' : context.extensionPath + '/.cwtools'
 
-	const init = async function(language : string, isVanillaFolder : boolean) {
-		vs.languages.setLanguageConfiguration(language, { wordPattern : /"?([^\s.]+)"?/ })
+	const init = async function (language: string, isVanillaFolder: boolean) {
+		vs.languages.setLanguageConfiguration(language, { wordPattern: /"?([^\s.]+)"?/ })
 		// The server is implemented using dotnet core
 		let serverExe: string;
 		if (os.platform() == "win32") {
@@ -83,10 +83,10 @@ export async function activate(context: ExtensionContext) {
 
 		// If the extension is launched in debug mode then the debug server options are used
 		// Otherwise the run options are used
-		const serverOptions: ServerOptions = {
+		const serverOptions = {
 			run: { command: serverExe, transport: TransportKind.stdio },
-			debug : { command: serverExe, transport: TransportKind.stdio }
-		}
+			debug: { command: serverExe, transport: TransportKind.stdio }
+		};
 
 		const fileEvents = [
 			workspace.createFileSystemWatcher("**/{events,common,map,map_data,prescripted_countries,flags,decisions,missions}/**/*.txt"),
@@ -101,8 +101,8 @@ export async function activate(context: ExtensionContext) {
 		const clientOptions: LanguageClientOptions = {
 			// Register the server for F# documents
 			documentSelector: [{ scheme: 'file', language: 'paradox' }, { scheme: 'file', language: 'yaml' }, { scheme: 'file', language: 'stellaris' },
-				{ scheme: 'file', language: 'hoi4' }, { scheme: 'file', language: 'eu4' }, { scheme: 'file', language: 'ck2' }, { scheme: 'file', language: 'imperator' }
-				, { scheme: 'file', language: 'vic2' }, { scheme: 'file', language: 'vic3' }, { scheme: 'file', language: 'ck3' }, { scheme: 'file', language: 'eu5' }, { scheme: 'file', language: 'paradox'}],
+			{ scheme: 'file', language: 'hoi4' }, { scheme: 'file', language: 'eu4' }, { scheme: 'file', language: 'ck2' }, { scheme: 'file', language: 'imperator' }
+				, { scheme: 'file', language: 'vic2' }, { scheme: 'file', language: 'vic3' }, { scheme: 'file', language: 'ck3' }, { scheme: 'file', language: 'eu5' }, { scheme: 'file', language: 'paradox' }],
 			synchronize: {
 				// Synchronize the setting section 'languageServerExample' to the server
 				configurationSection: 'cwtools',
@@ -116,8 +116,9 @@ export async function activate(context: ExtensionContext) {
 				rulesCache: cacheDir,
 				rules_version: workspace.getConfiguration('cwtools').get('rules_version'),
 				repoPath: repoPath,
-				diagnosticLogging: workspace.getConfiguration('cwtools').get('logging.diagnostic') },
-				revealOutputChannelOn: RevealOutputChannelOn.Error
+				diagnosticLogging: workspace.getConfiguration('cwtools').get('logging.diagnostic')
+			},
+			revealOutputChannelOn: RevealOutputChannelOn.Error
 		}
 
 		const client = new LanguageClient('cwtools', 'Paradox Language Server', serverOptions, clientOptions);
@@ -133,23 +134,22 @@ export async function activate(context: ExtensionContext) {
 		const promptReload = new NotificationType<string>('promptReload')
 		const forceReload = new NotificationType<string>('forceReload')
 		const promptVanillaPath = new NotificationType<string>('promptVanillaPath')
-		interface DidFocusFile { uri : string }
+		interface DidFocusFile { uri: string }
 		const didFocusFile = new NotificationType<DidFocusFile>('didFocusFile')
 		let status: Disposable;
 		interface UpdateFileList { fileList: FileListItem[] }
 		const updateFileList = new NotificationType<UpdateFileList>('updateFileList');
 
-		let latestType : string;
+		let latestType: string;
 
-		async function didChangeActiveTextEditor(editor : vs.TextEditor | undefined): Promise<void> {
-			if (editor){
+		async function didChangeActiveTextEditor(editor: vs.TextEditor | undefined): Promise<void> {
+			if (editor) {
 				const path = editor.document.uri.toString();
 				if (languageId == "paradox" && editor.document.languageId == "plaintext") {
 					await vs.languages.setTextDocumentLanguage(editor.document, "paradox")
 				}
-				if(editor.document.languageId == language)
-				{
-					await client.sendNotification(didFocusFile, {uri: path});
+				if (editor.document.languageId == language) {
+					await client.sendNotification(didFocusFile, { uri: path });
 				}
 				const params: ExecuteCommandParams = {
 					command: "getFileTypes",
@@ -169,8 +169,8 @@ export async function activate(context: ExtensionContext) {
 		context.subscriptions.push(window.onDidChangeActiveTextEditor(didChangeActiveTextEditor));
 
 		if (languageId == "paradox") {
-			for (const textDocument of workspace.textDocuments){
-				if (textDocument.languageId == "plaintext"){
+			for (const textDocument of workspace.textDocuments) {
+				if (textDocument.languageId == "plaintext") {
 					await vs.languages.setTextDocumentLanguage(textDocument, "paradox")
 				}
 			}
@@ -231,16 +231,16 @@ export async function activate(context: ExtensionContext) {
 				case "eu5": gameDisplay = "Europa Universalis V"; break;
 			}
 			const result = await window.showInformationMessage("Please select the vanilla installation folder for " + gameDisplay, "Select folder");
-			if(!result) {
+			if (!result) {
 				return;
 			}
 			const uri = await window.showOpenDialog({
-						canSelectFiles: false,
-						canSelectFolders: true,
-						canSelectMany: false,
-						openLabel: "Select vanilla installation folder for " + gameDisplay
-					});
-			if(!uri) {
+				canSelectFiles: false,
+				canSelectFolders: true,
+				canSelectMany: false,
+				openLabel: "Select vanilla installation folder for " + gameDisplay
+			});
+			if (!uri) {
 				return;
 			}
 			const directory = uri[0];
@@ -270,10 +270,10 @@ export async function activate(context: ExtensionContext) {
 					game = "imperator";
 					dir = path.join(dir, "game");
 					break;
-                case "Europa Universalis V":
-                    game = "eu5";
-                    dir = path.join(dir, "game");
-                    break;
+				case "Europa Universalis V":
+					game = "eu5";
+					dir = path.join(dir, "game");
+					break;
 			}
 			console.log(path.join(dir, "common"));
 			if (game === "" || !(fs.existsSync(path.join(dir, "common")))) {
@@ -296,11 +296,162 @@ export async function activate(context: ExtensionContext) {
 			}
 		})
 
+		// Memory usage status bar — polls the server process every 60 seconds
+		const PROCD_NAME = process.platform === 'win32' ? 'CWTools Server' : 'CWTools Server';
+		const memoryBar = window.createStatusBarItem(vs.StatusBarAlignment.Right, 100);
+		memoryBar.command = 'cwtools.showMemoryDetails';
+		memoryBar.name = 'CWTools Memory';
+		memoryBar.text = '$(database) ?MB';
+		memoryBar.tooltip = 'Starting up…';
+		memoryBar.show();
+		context.subscriptions.push(memoryBar);
+
+		let latestPid = 0;
+		let latestWs = 0;
+		let cachedPid: number | undefined;
+		let cachedDetails: any = undefined;  // cached result from getMemoryDetails
+
+		const queryServerMemory = (): number | undefined => {
+			try {
+				const cmd = process.platform === 'win32'
+					? `powershell -NoProfile -NonInteractive -Command "&{$p=Get-Process -Name '${PROCD_NAME}' -ErrorAction SilentlyContinue|Select-Object -First 1;if($p){Write-Output ($p.Id.ToString()+'|'+$p.WorkingSet64.ToString())}}"`
+					: `bash -c 'p=\$(pgrep -f "${PROCD_NAME}" | head -1); [ -n "$p" ] && ps -o rss= -p $p | xargs -I{} echo "$p|$(({} * 1024))"'`;
+				const output = child_process.execSync(cmd, { encoding: 'utf8', timeout: 5000 }).trim();
+				const parts = output.split('|');
+				if (parts.length === 2) {
+					const pid = parseInt(parts[0], 10);
+					const ws = parseInt(parts[1], 10);
+					if (!isNaN(pid) && pid > 0 && !isNaN(ws) && ws > 0) {
+						cachedPid = pid;
+						return ws;
+					}
+				}
+			} catch { /* process not yet available */ }
+			return undefined;
+		};
+
+		// Fetch detailed stats from server (5-min interval, less frequent than total memory poll)
+		const fetchMemoryDetails = async () => {
+			try {
+				const params: ExecuteCommandParams = { command: "getMemoryDetails", arguments: [] };
+				const result: any = await client.sendRequest(ExecuteCommandRequest.type, params);
+				if (result) { cachedDetails = result; }
+			} catch { /* server command not ready */ }
+		};
+
+		// Helper: get localized label from server response, fallback to English key
+		const loc = (key: string, fallback: string): string => {
+			return cachedDetails?.locLabels?.[key] ?? fallback;
+		};
+
+		const updateMemoryBar = () => {
+			const ws = queryServerMemory();
+			if (ws !== undefined) {
+				latestWs = ws;
+				const mb = (ws / 1048576).toFixed(0);
+				// Build tooltip with fragmentation info if available
+				let tip = `${loc('clickForDetails', 'Click for details')}  (PID ${cachedPid ?? '?'})`;
+				if (cachedDetails) {
+					const mh = (cachedDetails.managedHeap / 1048576).toFixed(0);
+					const nm = (cachedDetails.nonManagedMB ?? 0);
+					const pct = ws > 0 ? ((nm * 1048576 / ws) * 100).toFixed(0) : '?';
+					tip += `\n${loc('managedHeap', 'Managed Heap')}: ${mh} MB | ${loc('unmanaged', 'Unmanaged')}: ${nm} MB (${pct}%)`;
+				}
+				tip += `\n${loc('totalWorkingSet', 'Total Working Set')}: ${mb} MB`;
+				memoryBar.text = `$(database) ${mb}MB`;
+				memoryBar.tooltip = tip;
+			}
+		};
+
+		// First reading after 3s, then every 60s
+		setTimeout(updateMemoryBar, 3000);
+		const memTimer = setInterval(updateMemoryBar, 60000);
+		context.subscriptions.push({ dispose: () => clearInterval(memTimer) });
+		// Fetch detailed stats every 5 minutes
+		setTimeout(fetchMemoryDetails, 10000);
+		const detailTimer = setInterval(fetchMemoryDetails, 300000);
+		context.subscriptions.push({ dispose: () => clearInterval(detailTimer) });
+
+		context.subscriptions.push(commands.registerCommand('cwtools.showMemoryDetails', async () => {
+			const mb = (latestWs / 1048576).toFixed(0);
+			const pid = cachedPid ?? '?';
+			// Always fetch fresh data on click
+			try {
+				const params: ExecuteCommandParams = { command: "getMemoryDetails", arguments: [] };
+				const result: any = await client.sendRequest(ExecuteCommandRequest.type, params);
+				if (result) { cachedDetails = result; }
+			} catch (_e) { /* server command not available */ }
+			const r = cachedDetails;
+			if (r) {
+				const L = (key: string, fallback: string): string => r?.locLabels?.[key] ?? fallback;
+				const wsMB = (r.processWorkingSet / 1048576).toFixed(0);
+				const mhMB = (r.managedHeap / 1048576).toFixed(0);
+				const nmMB = r.nonManagedMB ?? 0;
+				const nmPct = r.processWorkingSet > 0 ? ((nmMB * 1048576 / r.processWorkingSet) * 100).toFixed(0) : '?';
+				const entityF = r.entityFiles ?? '?';
+				const fileR = r.fileResources ?? '?';
+				const fwcF = r.fileWithContentFiles ?? '?';
+				const openDocs = r.openDocuments ?? '?';
+				const entityCache = r.entityCacheEntries >= 0 ? r.entityCacheEntries.toLocaleString() : '?';
+				const valErr = r.totalValidationErrors ?? '?';
+				const locErr = r.totalLocalisationErrors ?? '?';
+				const locCache = r.locCacheEntries ?? '?';
+				const tds = r.typeDefinitions ?? '?';
+				const tes = r.typeEntries ?? '?';
+				const efs = r.scriptedEffects ?? '?';
+				const trs = r.scriptedTriggers ?? '?';
+				const sms = r.staticModifiers ?? '?';
+				const strKeys = r.internedUniqueKeys >= 0 ? r.internedUniqueKeys.toLocaleString() : '?';
+				const strTotal = r.internedTotalEntries >= 0 ? r.internedTotalEntries.toLocaleString() : '?';
+				const gc0 = r.gcGen0 ?? '?';
+				const gc1 = r.gcGen1 ?? '?';
+				const gc2 = r.gcGen2 ?? '?';
+				const allocMB = r.gcTotalAllocatedMB ?? '?';
+				window.showInformationMessage(
+					`${L('title', 'CWTools Memory Details')} (PID ${pid})` +
+					`\n━━━ ${L('sectionProcessMemory', 'Process Memory')} ━━━` +
+					`\n${L('workingSet', 'Working Set')}:  ${wsMB} MB` +
+					`\n${L('managedHeap', 'Managed Heap')}:      ${mhMB} MB` +
+					`\n${L('unmanaged', 'Unmanaged')}:      ${nmMB} MB (${nmPct}%)` +
+					`\n━━━ ${L('sectionGcStatus', 'GC Status')} ━━━` +
+					`\n  ${L('gcCollections', 'Gen0/1/2 Collections')}: ${gc0} / ${gc1} / ${gc2}` +
+					`\n  ${L('totalAllocated', 'Total Allocated')}:   ${allocMB} MB` +
+					`\n━━━ ${L('sectionFileCache', 'File Cache')} (${r.totalFiles ?? '?'}) ━━━` +
+					`\n  ${L('parsedEntities', 'Parsed Entities')}:  ${entityF}  (${L('parsedEntitiesHint', 'AST parse trees')})` +
+					`\n  ${L('fileReferences', 'File References')}:  ${fileR}  (${L('fileReferencesHint', 'dds/png etc.')})` +
+					`\n  ${L('filesWithContent', 'Files With Content')}:  ${fwcF}  (${L('filesWithContentHint', 'yml localisation')})` +
+					`\n  ${L('entityCacheEntries', 'Entity Cache Entries')}: ${entityCache}  (${L('entityCacheHint', 'entitiesMap')})` +
+					`\n  ${L('openDocuments', 'Open Documents')}: ${openDocs}` +
+					`\n━━━ ${L('sectionTypeSystem', 'Type System')} ━━━` +
+					`\n  ${L('typeDefinitions', 'Type Definitions')}:    ${tds}` +
+					`\n  ${L('typeEntries', 'Type Entries')}:    ${tes}` +
+					`\n  ${L('scriptedEffects', 'Scripted Effects')}:    ${efs}` +
+					`\n  ${L('scriptedTriggers', 'Scripted Triggers')}:  ${trs}` +
+					(r.scriptedTriggersGrowth > 0 && r.scriptedTriggersPrev >= 0 ? ` ⚠️ +${r.scriptedTriggersGrowth.toLocaleString()}` : '') +
+					`\n  ${L('staticModifiers', 'Static Modifiers')}:  ${sms}` +
+					`\n━━━ ${L('sectionValidationCache', 'Validation Cache')} ━━━` +
+					`\n  ${L('validationErrors', 'Validation Errors')}:    ${valErr}` +
+					`\n  ${L('localisationErrors', 'Localisation Errors')}:  ${locErr}` +
+					`\n  ${L('locCacheEntries', 'Loc Cache Entries')}:    ${locCache}` +
+					`\n━━━ ${L('sectionStringInterning', 'String Interning')} ━━━` +
+					`\n  ${L('uniqueKeys', 'Unique Keys')}:      ${strKeys}` +
+					`\n  ${L('totalEntries', 'Total Entries')}:      ${strTotal}`,
+					{ modal: false }
+				);
+				return;
+			}
+			// Fallback if server command fails
+			window.showInformationMessage(
+				`CWTools Language Server\nPID: ${pid}\nWorking Set: ${mb} MB`,
+				{ modal: false }
+			);
+		}));
+
 		if (workspace.name === undefined) {
 			await window.showWarningMessage("You have opened a file directly.\n\rFor CWTools to work correctly, the mod folder should be opened using \"File, Open Folder\"")
 		}
 
-/// TODO graph
+		/// TODO graph
 		// let disposable2 = commands.registerCommand('techGraph', () => {
 		// 	commands.executeCommand("gettech").then((t: any) => {
 		// 		//console.log(t);
@@ -319,9 +470,9 @@ export async function activate(context: ExtensionContext) {
 		// });
 
 		let currentGraphDepth = 3;
-		const showGraph = async function() {
+		const showGraph = async function () {
 			const graphData = await getGraphData(latestType, currentGraphDepth);
-			const wheelSensitivity : number = workspace.getConfiguration('cwtools.graph').get('zoomSensitivity') ?? 1;
+			const wheelSensitivity: number = workspace.getConfiguration('cwtools.graph').get('zoomSensitivity') ?? 1;
 			gp.GraphPanel.create(context.extensionPath);
 			gp.GraphPanel.currentPanel!.initialiseGraph(graphData, wheelSensitivity);
 		}
@@ -334,17 +485,16 @@ export async function activate(context: ExtensionContext) {
 					placeHolder: "default: 3",
 					prompt: "Set graph depth (how many connections to go back from this file)",
 					value: currentGraphDepth.toString(),
-					validateInput: (v : string) => Number.isInteger(Number(v)) ? undefined : "Please enter a number"
-			 });
-				if (Number.isInteger(Number(res)))
-			{
+					validateInput: (v: string) => Number.isInteger(Number(v)) ? undefined : "Please enter a number"
+				});
+			if (Number.isInteger(Number(res))) {
 				currentGraphDepth = Number(res)
 				await showGraph()
 			}
 		}));
 		context.subscriptions.push(commands.registerCommand('graphFromJson', async () => {
-			const uri = await window.showOpenDialog({filters: {'Json': ['json']}})
-			if(!uri){
+			const uri = await window.showOpenDialog({ filters: { 'Json': ['json'] } })
+			if (!uri) {
 				return;
 			}
 			const bytes = await vs.workspace.fs.readFile(uri[0]);
@@ -371,9 +521,9 @@ export async function activate(context: ExtensionContext) {
 		await client.start();
 	}
 
-	let languageId : string;
+	let languageId: string;
 	const knownLanguageIds = ["stellaris", "eu4", "hoi4", "ck2", "imperator", "vic2", "vic3", "ck3", "eu5"];
-	const getLanguageIdFallback = async function() {
+	const getLanguageIdFallback = async function () {
 		const markerFiles = await workspace.findFiles("**/*.txt", null, 1);
 		if (markerFiles.length == 1) {
 			return (await workspace.openTextDocument(markerFiles[0])).languageId;
@@ -382,7 +532,7 @@ export async function activate(context: ExtensionContext) {
 	}
 
 	let guessedLanguageId: string | undefined | null = window.activeTextEditor?.document?.languageId;
-	if(guessedLanguageId === undefined || !knownLanguageIds.includes(guessedLanguageId)){
+	if (guessedLanguageId === undefined || !knownLanguageIds.includes(guessedLanguageId)) {
 		guessedLanguageId = await getLanguageIdFallback();
 	}
 
@@ -395,7 +545,7 @@ export async function activate(context: ExtensionContext) {
 		case "vic2": languageId = "vic2"; break;
 		case "vic3": languageId = "vic3"; break;
 		case "ck3": languageId = "ck3"; break;
-        case "eu5": languageId = "eu5"; break;
+		case "eu5": languageId = "eu5"; break;
 		default: languageId = "paradox"; break;
 	}
 	async function findExeInFiles(gameExeName: string, binariesPrefix = false) {
@@ -429,7 +579,7 @@ export async function activate(context: ExtensionContext) {
 		{ id: "vic2", exeName: "v2game", binariesPrefix: false },
 		{ id: "ck3", exeName: "ck3", binariesPrefix: true },
 		{ id: "vic3", exeName: "victoria3", binariesPrefix: true },
-        { id: "eu5", exeName: "eu5", binariesPrefix: true },
+		{ id: "eu5", exeName: "eu5", binariesPrefix: true },
 	];
 
 	const promises = games.map(({ exeName, binariesPrefix }) =>
@@ -460,12 +610,12 @@ export async function activate(context: ExtensionContext) {
 }
 
 
-export async function reloadExtension(prompt: string, buttonText?: string, force? : boolean) {
+export async function reloadExtension(prompt: string, buttonText?: string, force?: boolean) {
 	const restartAction = buttonText || "Restart";
 	const actions = [restartAction];
 	if (force) {
 		const result = await window.showInformationMessage(prompt);
-		if(result){
+		if (result) {
 			await commands.executeCommand("cwtools.reloadExtension");
 		}
 	}

--- a/release/package.json
+++ b/release/package.json
@@ -5,7 +5,7 @@
   "description": "%extension.description%",
   "author": "Dayshine",
   "license": "MIT",
-  "version": "0.10.31",
+  "version": "0.10.32",
   "preview": true,
   "publisher": "tboby",
   "qna": "https://forum.paradoxplaza.com/forum/index.php?threads/tool-cwtools-a-mod-validating-extension-for-vs-code.1066033/",

--- a/src/Languages/LangResources.resx
+++ b/src/Languages/LangResources.resx
@@ -30,4 +30,103 @@
     <data name="loadingBar.ValidatingFiles" xml:space="preserve">
         <value>Validating files...</value>
     </data>
+    <data name="memoryMonitor.title" xml:space="preserve">
+        <value>CWTools Memory Details (PID {0})</value>
+    </data>
+    <data name="memoryMonitor.section.processMemory" xml:space="preserve">
+        <value>Process Memory</value>
+    </data>
+    <data name="memoryMonitor.workingSet" xml:space="preserve">
+        <value>Working Set</value>
+    </data>
+    <data name="memoryMonitor.managedHeap" xml:space="preserve">
+        <value>Managed Heap</value>
+    </data>
+    <data name="memoryMonitor.unmanaged" xml:space="preserve">
+        <value>Unmanaged</value>
+    </data>
+    <data name="memoryMonitor.section.gcStatus" xml:space="preserve">
+        <value>GC Status</value>
+    </data>
+    <data name="memoryMonitor.gcCollections" xml:space="preserve">
+        <value>Gen0/1/2 Collections</value>
+    </data>
+    <data name="memoryMonitor.totalAllocated" xml:space="preserve">
+        <value>Total Allocated</value>
+    </data>
+    <data name="memoryMonitor.section.fileCache" xml:space="preserve">
+        <value>File Cache ({0})</value>
+    </data>
+    <data name="memoryMonitor.parsedEntities" xml:space="preserve">
+        <value>Parsed Entities</value>
+    </data>
+    <data name="memoryMonitor.parsedEntitiesHint" xml:space="preserve">
+        <value>AST parse trees</value>
+    </data>
+    <data name="memoryMonitor.fileReferences" xml:space="preserve">
+        <value>File References</value>
+    </data>
+    <data name="memoryMonitor.fileReferencesHint" xml:space="preserve">
+        <value>dds/png etc.</value>
+    </data>
+    <data name="memoryMonitor.filesWithContent" xml:space="preserve">
+        <value>Files With Content</value>
+    </data>
+    <data name="memoryMonitor.filesWithContentHint" xml:space="preserve">
+        <value>yml localisation</value>
+    </data>
+    <data name="memoryMonitor.entityCacheEntries" xml:space="preserve">
+        <value>Entity Cache Entries</value>
+    </data>
+    <data name="memoryMonitor.entityCacheHint" xml:space="preserve">
+        <value>entitiesMap</value>
+    </data>
+    <data name="memoryMonitor.openDocuments" xml:space="preserve">
+        <value>Open Documents</value>
+    </data>
+    <data name="memoryMonitor.section.typeSystem" xml:space="preserve">
+        <value>Type System</value>
+    </data>
+    <data name="memoryMonitor.typeDefinitions" xml:space="preserve">
+        <value>Type Definitions</value>
+    </data>
+    <data name="memoryMonitor.typeEntries" xml:space="preserve">
+        <value>Type Entries</value>
+    </data>
+    <data name="memoryMonitor.scriptedEffects" xml:space="preserve">
+        <value>Scripted Effects</value>
+    </data>
+    <data name="memoryMonitor.scriptedTriggers" xml:space="preserve">
+        <value>Scripted Triggers</value>
+    </data>
+    <data name="memoryMonitor.staticModifiers" xml:space="preserve">
+        <value>Static Modifiers</value>
+    </data>
+    <data name="memoryMonitor.section.validationCache" xml:space="preserve">
+        <value>Validation Cache</value>
+    </data>
+    <data name="memoryMonitor.validationErrors" xml:space="preserve">
+        <value>Validation Errors</value>
+    </data>
+    <data name="memoryMonitor.localisationErrors" xml:space="preserve">
+        <value>Localisation Errors</value>
+    </data>
+    <data name="memoryMonitor.locCacheEntries" xml:space="preserve">
+        <value>Loc Cache Entries</value>
+    </data>
+    <data name="memoryMonitor.section.stringInterning" xml:space="preserve">
+        <value>String Interning</value>
+    </data>
+    <data name="memoryMonitor.uniqueKeys" xml:space="preserve">
+        <value>Unique Keys</value>
+    </data>
+    <data name="memoryMonitor.totalEntries" xml:space="preserve">
+        <value>Total Entries</value>
+    </data>
+    <data name="memoryMonitor.clickForDetails" xml:space="preserve">
+        <value>Click for details</value>
+    </data>
+    <data name="memoryMonitor.totalWorkingSet" xml:space="preserve">
+        <value>Total Working Set</value>
+    </data>
 </root>

--- a/src/Languages/LangResources.zh-Hans.resx
+++ b/src/Languages/LangResources.zh-Hans.resx
@@ -23,4 +23,103 @@
     <data name="loadingBar.ValidatingFiles" xml:space="preserve">
         <value>正在验证文件...</value>
     </data>
+    <data name="memoryMonitor.title" xml:space="preserve">
+        <value>CWTools 内存详情 (PID {0})</value>
+    </data>
+    <data name="memoryMonitor.section.processMemory" xml:space="preserve">
+        <value>进程内存</value>
+    </data>
+    <data name="memoryMonitor.workingSet" xml:space="preserve">
+        <value>进程工作集</value>
+    </data>
+    <data name="memoryMonitor.managedHeap" xml:space="preserve">
+        <value>托管堆</value>
+    </data>
+    <data name="memoryMonitor.unmanaged" xml:space="preserve">
+        <value>非托管</value>
+    </data>
+    <data name="memoryMonitor.section.gcStatus" xml:space="preserve">
+        <value>GC 状态</value>
+    </data>
+    <data name="memoryMonitor.gcCollections" xml:space="preserve">
+        <value>Gen0/1/2 回收</value>
+    </data>
+    <data name="memoryMonitor.totalAllocated" xml:space="preserve">
+        <value>累计分配</value>
+    </data>
+    <data name="memoryMonitor.section.fileCache" xml:space="preserve">
+        <value>文件缓存 ({0})</value>
+    </data>
+    <data name="memoryMonitor.parsedEntities" xml:space="preserve">
+        <value>已解析实体</value>
+    </data>
+    <data name="memoryMonitor.parsedEntitiesHint" xml:space="preserve">
+        <value>AST 解析树</value>
+    </data>
+    <data name="memoryMonitor.fileReferences" xml:space="preserve">
+        <value>纯文件引用</value>
+    </data>
+    <data name="memoryMonitor.fileReferencesHint" xml:space="preserve">
+        <value>dds/png 等</value>
+    </data>
+    <data name="memoryMonitor.filesWithContent" xml:space="preserve">
+        <value>含内容文件</value>
+    </data>
+    <data name="memoryMonitor.filesWithContentHint" xml:space="preserve">
+        <value>yml 本地化</value>
+    </data>
+    <data name="memoryMonitor.entityCacheEntries" xml:space="preserve">
+        <value>实体缓存条目</value>
+    </data>
+    <data name="memoryMonitor.entityCacheHint" xml:space="preserve">
+        <value>entitiesMap</value>
+    </data>
+    <data name="memoryMonitor.openDocuments" xml:space="preserve">
+        <value>当前打开文档</value>
+    </data>
+    <data name="memoryMonitor.section.typeSystem" xml:space="preserve">
+        <value>类型系统</value>
+    </data>
+    <data name="memoryMonitor.typeDefinitions" xml:space="preserve">
+        <value>类型定义</value>
+    </data>
+    <data name="memoryMonitor.typeEntries" xml:space="preserve">
+        <value>类型条目</value>
+    </data>
+    <data name="memoryMonitor.scriptedEffects" xml:space="preserve">
+        <value>脚本效果</value>
+    </data>
+    <data name="memoryMonitor.scriptedTriggers" xml:space="preserve">
+        <value>脚本触发器</value>
+    </data>
+    <data name="memoryMonitor.staticModifiers" xml:space="preserve">
+        <value>静态修饰符</value>
+    </data>
+    <data name="memoryMonitor.section.validationCache" xml:space="preserve">
+        <value>验证缓存</value>
+    </data>
+    <data name="memoryMonitor.validationErrors" xml:space="preserve">
+        <value>验证错误</value>
+    </data>
+    <data name="memoryMonitor.localisationErrors" xml:space="preserve">
+        <value>本地化错误</value>
+    </data>
+    <data name="memoryMonitor.locCacheEntries" xml:space="preserve">
+        <value>Loc 缓存</value>
+    </data>
+    <data name="memoryMonitor.section.stringInterning" xml:space="preserve">
+        <value>字符串驻留</value>
+    </data>
+    <data name="memoryMonitor.uniqueKeys" xml:space="preserve">
+        <value>唯一键</value>
+    </data>
+    <data name="memoryMonitor.totalEntries" xml:space="preserve">
+        <value>总条目</value>
+    </data>
+    <data name="memoryMonitor.clickForDetails" xml:space="preserve">
+        <value>点击查看详情</value>
+    </data>
+    <data name="memoryMonitor.totalWorkingSet" xml:space="preserve">
+        <value>总工作集</value>
+    </data>
 </root>

--- a/src/Main/Completion.fs
+++ b/src/Main/Completion.fs
@@ -29,6 +29,12 @@ let mutable completionCacheCount = 0
 let mutable private completionPartialCache: (CompletionParams * CompletionItem seq) option =
     None
 
+let clearCompletionCaches () =
+    completionCache.Clear()
+    rangeCache <- None
+    completionPartialCache <- None
+    completionCacheCount <- 0
+
 let completionResolveItem (gameObj: IGame option) (item: CompletionItem) =
     async {
         logInfo "Completion resolve"
@@ -157,7 +163,8 @@ let computeCompletionRanges (filetext: string) (line: int) (character: int) =
         (insertRange, replaceRange)
 
 let optimiseCompletion (completionList: CompletionItem seq) =
-    if completionCacheCount > 2 then
+    // Clear cache more aggressively - every other call
+    if completionCacheCount > 1 then
         completionCache.Clear()
         completionCacheCount <- 0
     else

--- a/src/Main/Program.fs
+++ b/src/Main/Program.fs
@@ -8,6 +8,7 @@ open CWTools.Parser
 open CWTools.Common
 open CWTools.Games
 open FParsec
+open System.Threading
 open System.Threading.Tasks
 open System.Text
 open System.Reflection
@@ -74,6 +75,8 @@ type Server(client: ILanguageClient) =
     do setupLogger client
     let docs = DocumentStore()
 
+
+
     let notFound (doc: Uri) () : 'Any =
         raise (Exception $"%s{doc.ToString()} does not exist")
 
@@ -125,6 +128,21 @@ type Server(client: ILanguageClient) =
     let mutable lastFocusedFile: string option = None
 
     let mutable currentlyRefreshingFiles: bool = false
+    /// Counter for periodic deep cleanup (every N full analyses)
+    let mutable cleanupCounter = 0
+    let cleanupInterval = 10
+
+    let clearGameCaches () =
+        match gameObj with
+        | Some game ->
+            logDiag "Performing deep cache cleanup"
+            game.ClearValidationCache()
+            game.ClearResources()
+            clearCompletionCaches ()
+            GC.Collect(2, GCCollectionMode.Optimized, true)
+            GC.WaitForPendingFinalizers()
+            logDiag "Deep cache cleanup completed"
+        | None -> ()
 
     let (|TrySuccess|TryFailure|) tryResult =
         match tryResult with
@@ -269,12 +287,14 @@ type Server(client: ILanguageClient) =
         }
 
     let mutable delayTime = TimeSpan(0, 0, 30)
-
+    /// Track trigger count across RefreshCaches() to detect accumulation leaks
+    let mutable previousTriggerCount = -1
     let delayedAnalyze () =
         match gameObj with
         | Some game ->
             let timestamp = Stopwatch.GetTimestamp()
             game.RefreshCaches()
+            previousTriggerCount <- game.ScriptedTriggers() |> List.length
 
             if delayedLocUpdate then
                 logDiag "delayedLocUpdate true"
@@ -298,7 +318,17 @@ type Server(client: ILanguageClient) =
 
             delayTime <-
                 TimeSpan(Math.Min(TimeSpan(0, 0, 60).Ticks, Math.Max(TimeSpan(0, 0, 10).Ticks, 3L * time.Ticks)))
-        //GC.Collect(2, System.GCCollectionMode.Optimized, false, false)
+
+            // Periodic memory cleanup
+            cleanupCounter <- cleanupCounter + 1
+
+            if cleanupCounter >= cleanupInterval then
+                cleanupCounter <- 0
+                logDiag "Triggering deep memory cleanup"
+                clearGameCaches ()
+            else
+                // Lightweight GC between deep cleanups
+                GC.Collect(2, GCCollectionMode.Optimized, false)
         | None -> ()
 
     let lintAgent =
@@ -844,7 +874,8 @@ type Server(client: ILanguageClient) =
                                           "listAllLocFiles"
                                           "gettech"
                                           "getGraphData"
-                                          "exportTypes" ] } } }
+                                          "exportTypes"
+                                          "getMemoryDetails" ] } } }
             }
 
         member this.Initialized() = async { () }
@@ -1713,6 +1744,134 @@ type Server(client: ILanguageClient) =
 
                                 None
                             | _ -> None
+                        | { command = "getMemoryDetails"
+                            arguments = _ } ->
+                            let proc = Process.GetCurrentProcess()
+                            // ── File breakdown from AllFiles() ──
+                            let allFiles = match gameObj with Some g -> g.AllFiles() | None -> []
+                            let totalFiles = allFiles.Length
+                            let entityFiles = allFiles |> List.choose (function EntityResource _ -> Some 1 | _ -> None) |> List.length
+                            let fileResources = allFiles |> List.choose (function FileResource _ -> Some 1 | _ -> None) |> List.length
+                            let fileWithContentFiles = allFiles |> List.choose (function FileWithContentResource _ -> Some 1 | _ -> None) |> List.length
+                            // ── Open documents in DocumentStore ──
+                            let openDocs = docs.OpenFiles() |> List.length
+                            // ── Validation / errors ──
+                            let valErrors = match gameObj with Some g -> g.ValidationErrors() |> List.length | None -> 0
+                            let locErrors = match gameObj with Some g -> g.LocalisationErrors(false, true) |> List.length | None -> 0
+                            let locCacheCount = locCache |> Map.count
+                            // ── Type system / effects / triggers ──
+                            let typeDefCount, typeEntryCount, effectsCount, triggersCount, staticModCount =
+                                match gameObj with
+                                | Some g ->
+                                    let tds = g.TypeDefs() |> List.length
+                                    let tes = g.Types() |> Map.toList |> List.sumBy (fun (_, arr) -> arr.Length)
+                                    let efs = g.ScriptedEffects() |> List.length
+                                    let trs = g.ScriptedTriggers() |> List.length
+                                    let sms = g.StaticModifiers() |> Array.length
+                                    tds, tes, efs, trs, sms
+                                | None -> 0, 0, 0, 0, 0
+                            // ── String resource manager internals (via reflection) ──
+                            let stringUniqueKeys, stringTotalEntries =
+                                try
+                                    let sm = CWTools.Utilities.StringResource.stringManager
+                                    let t = sm.GetType()
+                                    let stringsField = t.GetField("strings", System.Reflection.BindingFlags.NonPublic ||| System.Reflection.BindingFlags.Instance)
+                                    let intsField = t.GetField("ints", System.Reflection.BindingFlags.NonPublic ||| System.Reflection.BindingFlags.Instance)
+                                    let stringsDict = stringsField.GetValue(sm)
+                                    let intsDict = intsField.GetValue(sm)
+                                    let uniqueKeys = stringsDict.GetType().GetProperty("Count").GetValue(stringsDict) :?> int
+                                    let totalEntries = intsDict.GetType().GetProperty("Count").GetValue(intsDict) :?> int
+                                    uniqueKeys, totalEntries
+                                with _ -> -1, -1
+                            // ── Try to get entitiesMap (the AST cache) size from ResourceManager via IGame<'T> ──
+                            let entityCacheCount =
+                                match stlGameObj, eu4GameObj, hoi4GameObj, ck2GameObj, irGameObj,
+                                      vic2GameObj, ck3GameObj, vic3GameObj, eu5GameObj, customGameObj with
+                                | Some g, _, _, _, _, _, _, _, _, _ -> g.AllEntities() |> Seq.length
+                                | _, Some g, _, _, _, _, _, _, _, _ -> g.AllEntities() |> Seq.length
+                                | _, _, Some g, _, _, _, _, _, _, _ -> g.AllEntities() |> Seq.length
+                                | _, _, _, Some g, _, _, _, _, _, _ -> g.AllEntities() |> Seq.length
+                                | _, _, _, _, Some g, _, _, _, _, _ -> g.AllEntities() |> Seq.length
+                                | _, _, _, _, _, Some g, _, _, _, _ -> g.AllEntities() |> Seq.length
+                                | _, _, _, _, _, _, Some g, _, _, _ -> g.AllEntities() |> Seq.length
+                                | _, _, _, _, _, _, _, Some g, _, _ -> g.AllEntities() |> Seq.length
+                                | _, _, _, _, _, _, _, _, Some g, _ -> g.AllEntities() |> Seq.length
+                                | _, _, _, _, _, _, _, _, _, Some g -> g.AllEntities() |> Seq.length
+                                | _ -> -1
+                            // Pre-compute localized labels for the memory monitor display
+                            let loc key = Languages.LangResources.ResourceManager.GetString(key, Languages.LangResources.Culture)
+                            let locLabels =
+                                JsonValue.Record [|
+                                "title", JsonValue.String(loc "memoryMonitor.title")
+                                "sectionProcessMemory", JsonValue.String(loc "memoryMonitor.section.processMemory")
+                                "workingSet", JsonValue.String(loc "memoryMonitor.workingSet")
+                                "managedHeap", JsonValue.String(loc "memoryMonitor.managedHeap")
+                                "unmanaged", JsonValue.String(loc "memoryMonitor.unmanaged")
+                                "sectionGcStatus", JsonValue.String(loc "memoryMonitor.section.gcStatus")
+                                "gcCollections", JsonValue.String(loc "memoryMonitor.gcCollections")
+                                "totalAllocated", JsonValue.String(loc "memoryMonitor.totalAllocated")
+                                "sectionFileCache", JsonValue.String(loc "memoryMonitor.section.fileCache")
+                                "parsedEntities", JsonValue.String(loc "memoryMonitor.parsedEntities")
+                                "parsedEntitiesHint", JsonValue.String(loc "memoryMonitor.parsedEntitiesHint")
+                                "fileReferences", JsonValue.String(loc "memoryMonitor.fileReferences")
+                                "fileReferencesHint", JsonValue.String(loc "memoryMonitor.fileReferencesHint")
+                                "filesWithContent", JsonValue.String(loc "memoryMonitor.filesWithContent")
+                                "filesWithContentHint", JsonValue.String(loc "memoryMonitor.filesWithContentHint")
+                                "entityCacheEntries", JsonValue.String(loc "memoryMonitor.entityCacheEntries")
+                                "entityCacheHint", JsonValue.String(loc "memoryMonitor.entityCacheHint")
+                                "openDocuments", JsonValue.String(loc "memoryMonitor.openDocuments")
+                                "sectionTypeSystem", JsonValue.String(loc "memoryMonitor.section.typeSystem")
+                                "typeDefinitions", JsonValue.String(loc "memoryMonitor.typeDefinitions")
+                                "typeEntries", JsonValue.String(loc "memoryMonitor.typeEntries")
+                                "scriptedEffects", JsonValue.String(loc "memoryMonitor.scriptedEffects")
+                                "scriptedTriggers", JsonValue.String(loc "memoryMonitor.scriptedTriggers")
+                                "staticModifiers", JsonValue.String(loc "memoryMonitor.staticModifiers")
+                                "sectionValidationCache", JsonValue.String(loc "memoryMonitor.section.validationCache")
+                                "validationErrors", JsonValue.String(loc "memoryMonitor.validationErrors")
+                                "localisationErrors", JsonValue.String(loc "memoryMonitor.localisationErrors")
+                                "locCacheEntries", JsonValue.String(loc "memoryMonitor.locCacheEntries")
+                                "sectionStringInterning", JsonValue.String(loc "memoryMonitor.section.stringInterning")
+                                "uniqueKeys", JsonValue.String(loc "memoryMonitor.uniqueKeys")
+                                "totalEntries", JsonValue.String(loc "memoryMonitor.totalEntries")
+                                "clickForDetails", JsonValue.String(loc "memoryMonitor.clickForDetails")
+                                "totalWorkingSet", JsonValue.String(loc "memoryMonitor.totalWorkingSet")
+                                |]
+                            Some(
+                                JsonValue.Record [|
+                                    // Total process
+                                    "processWorkingSet", JsonValue.Number(decimal proc.WorkingSet64)
+                                    "managedHeap", JsonValue.Number(decimal (GC.GetTotalMemory false))
+                                    // Files
+                                    "totalFiles", JsonValue.Number(decimal totalFiles)
+                                    "entityFiles", JsonValue.Number(decimal entityFiles)
+                                    "fileResources", JsonValue.Number(decimal fileResources)
+                                    "fileWithContentFiles", JsonValue.Number(decimal fileWithContentFiles)
+                                    "openDocuments", JsonValue.Number(decimal openDocs)
+                                    "entityCacheEntries", JsonValue.Number(decimal entityCacheCount)
+                                    // Validation
+                                    "totalValidationErrors", JsonValue.Number(decimal valErrors)
+                                    "totalLocalisationErrors", JsonValue.Number(decimal locErrors)
+                                    "locCacheEntries", JsonValue.Number(decimal locCacheCount)
+                                    // Type system
+                                    "typeDefinitions", JsonValue.Number(decimal typeDefCount)
+                                    "typeEntries", JsonValue.Number(decimal typeEntryCount)
+                                    "scriptedEffects", JsonValue.Number(decimal effectsCount)
+                                    "scriptedTriggers", JsonValue.Number(decimal triggersCount)
+                                    "scriptedTriggersPrev", JsonValue.Number(decimal previousTriggerCount)
+                                    "scriptedTriggersGrowth", JsonValue.Number(decimal (if previousTriggerCount >= 0 then max 0 (triggersCount - previousTriggerCount) else 0))
+                                    "staticModifiers", JsonValue.Number(decimal staticModCount)
+                                    // String interning
+                                    "internedUniqueKeys", JsonValue.Number(decimal stringUniqueKeys)
+                                    "internedTotalEntries", JsonValue.Number(decimal stringTotalEntries)
+                                    // GC diagnostics
+                                    "gcGen0", JsonValue.Number(decimal (GC.CollectionCount 0))
+                                    "gcGen1", JsonValue.Number(decimal (GC.CollectionCount 1))
+                                    "gcGen2", JsonValue.Number(decimal (GC.CollectionCount 2))
+                                    "gcTotalAllocatedMB", JsonValue.Number(decimal (GC.GetTotalAllocatedBytes() / 1048576L))
+                                    "nonManagedMB", JsonValue.Number(decimal (max 0L (proc.WorkingSet64 - (GC.GetTotalMemory false |> int64)) / 1048576L))
+                                    "locLabels", locLabels
+                                |]
+                            )
                         | _ -> None
                     | None -> None
             }


### PR DESCRIPTION
## Problem

The CWTools language server's memory grows continuously up to 12GB+ during long-running sessions. Root cause: `addDataEventTargetLinks()` creates `ScopedEffect` entries with `EffectType.ValueTrigger` that leak into `lookup.triggers`. Each `RefreshCaches` cycle reads these back from `lookup.triggers` and appends them again, adding ~**430k duplicate trigger entries per cycle** — growing from ~200k to over 3M within hours.

## Changes

### 1. Trigger accumulation fix (core)
- **STLGame**: Filter out `ScopedEffect` instances from `lookup.triggers` in `refreshConfigAfterFirstTypesHook` — these are data event target links, not real triggers. This breaks the cross-cycle accumulation feedback loop.
- **STLGame / HOI4 / EU4 / CK2**: `refreshConfigAfterVarDefHook` now uses `lookup.eventTargetLinks` instead of `updateEventTargetLinks + dataEventTargetLinksCache`, eliminating intra-cycle ValueTrigger duplication.
- **Lookup**: Added `dataEventTargetLinksCache` field to avoid redundant computation of `addDataEventTargetLinks`.

### 2. Cache cleanup API
- Added `ClearResources()` / `ClearValidationCache()` to `IGame` interface, implemented across all 10 game types.
- `ResourceManager.Clear()` — clears `fileMap` and `entitiesMap`.
- `ErrorCache.Clear()` — clears all cached validation errors.
- Periodic deep cleanup every 10 analysis cycles.

### 3. Memory monitoring
- Status bar showing server process memory, refreshed every 60s.
- Click for detailed breakdown (managed/unmanaged heap, GC stats, file cache, type system, trigger/effect counts, string interning, etc.).
- Localized labels (EN/ZH) via `.resx` resource files, following the system culture.

### 4. Other
- Periodic `GC.Collect` in `delayedAnalyze`.
- Version bump 0.10.31 → 0.10.32.

## ⚠️ Caveats & Risks

**This PR has NOT been thoroughly tested. Please be aware of the following before merging:**

1. **Only Stellaris has been verified.** HOI4/EU4/CK2 have the same fix pattern applied (VarDefHook uses `eventTargetLinks`), but have NOT been actually tested to confirm trigger count stops growing.

2. **ScopedEffect filtering is brittle.** The filter in STLGame assumes legitimate triggers are `DocEffect` or `ScriptedEffect` instances, and only data link entries are `ScopedEffect`. If any game defines real triggers as `ScopedEffect`, the filter will incorrectly remove them.

3. **Jomini-based games are NOT fixed.** CK3 / VIC3 / EU5 / IR / VIC2 share `Hooks.refreshConfigAfterHook`, which calls `addDataEventTargetLinks` in both first-types and var-def hooks. This likely has the same accumulation issue — **not yet investigated**.

4. **Cache clearing may cause CPU spikes.** `ClearResources()` drops all parsed ASTs; the next analysis cycle will re-parse everything. Deep cleanup runs every 10 cycles and may cause brief CPU spikes on large projects.

5. **GC.Collect overhead.** Periodic `GC.Collect(2, GCCollectionMode.Optimized)` may increase GC pause times on large projects.

## Merge Order

This PR depends on a companion PR in the cwtools submodule:

1. **First**: `Axis-qc/cwtools fix/memory-leak` → `cwtools/cwtools master` (15 files, +70/−13 lines)
2. **Then**: This PR → `cwtools/cwtools-vscode main`

The main repo's `submodules/cwtools` pointer references the new submodule commit. Merging in the wrong order will break the submodule reference.